### PR TITLE
[WIP]: add stratumv2 listening port configuration

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -594,6 +594,10 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-sandbox=<mode>", "Use the experimental syscall sandbox in the specified mode (-sandbox=log-and-abort or -sandbox=abort). Allow only expected syscalls to be used by bitcoind. Note that this is an experimental new feature that may cause bitcoind to exit or crash unexpectedly: use with caution. In the \"log-and-abort\" mode the invocation of an unexpected syscall results in a debug handler being invoked which will log the incident and terminate the program (without executing the unexpected syscall). In the \"abort\" mode the invocation of an unexpected syscall results in the entire process being killed immediately by the kernel without executing the unexpected syscall.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif // USE_SYSCALL_SANDBOX
 
+#if ENABLE_TEMPLATE_PROVIDER
+    argsman.AddArg("-stratumv2=<port>", "Listen for stratumv2 connections on <port>. Bitcoind will act as a Template Provider. (default: 8442)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+#endif
+
     // Add the hidden options
     argsman.AddHiddenArgs(hidden_args);
 }


### PR DESCRIPTION
TODO - Housekeeping:
* This is currently branched from [2022.05.17-fix-template-provider-compile-options](https://github.com/stratum-mining/bitcoin/pull/21), please review and merge that PR before attempting to merge this one.
* I will rebase this PR on top of [add_sv2](https://github.com/stratum-mining/bitcoin/tree/add_sv2) if the previously mentioned PR above is merged into [add_sv2](https://github.com/stratum-mining/bitcoin/tree/add_sv2). 
* This is an attempt to keep the commit diffs easier to review internally while still relying on WIP changes.

TODO - Discussion:

* The below are points that should be discussed/reviewed internally before making more progress on this specific topic:
    * [ ] I set a default port of `8442` for the listening port of the Template Provider on all environments, this is completely arbitrary. Is there a better port to use or one suggested by the specs?
    * [ ] Should we set default ports per Bitcoin environment? e.g. `8442 : mainnet`, `8444 : devnet`, `8445 : regtest` etc... 
        * Example: [Different RPC for different environments](https://github.com/bitcoin/bitcoin/blob/master/src/init.cpp#L576)
    * [ ] Currently assumes the server will bind to `0.0.0.0`, should we allow the user to also specify an address they can bind the to?